### PR TITLE
Make the compAngle variables public so they can be read ?

### DIFF
--- a/C++/six_axis_comp_filter.h
+++ b/C++/six_axis_comp_filter.h
@@ -90,7 +90,12 @@ CompSixAxis
         //      None.
         //
         CompSixAxis(float deltaTime, float tau);
-
+        
+        //
+        // Comp. filter angle output in relation to the X and Y axes.
+        //
+        float compAngleX, compAngleY;
+        
         //
         // Complementary Filter Start
         // Description:
@@ -104,6 +109,7 @@ CompSixAxis
         // Returns:
         //      None.
         //
+        
         void CompStart();
 
         //
@@ -210,11 +216,6 @@ CompSixAxis
         // Accelerometer angles in relation to the X and Y axes.
         //
         float accelAngleX, accelAngleY;
-
-        //
-        // Comp. filter angle output in relation to the X and Y axes.
-        //
-        float compAngleX, compAngleY;
 
         //
         // Extrapolates angles according to accelerometer readings


### PR DESCRIPTION
I noticed that the **compUpdate** function doesn't really return any values. I need to use those comp. angles so I thought it could be a good idea to make them public. (by the way, the library runs marvellously well on Arduino using the Sparkfun LSM6DS3 sensor)
